### PR TITLE
Fix deprecated pandoc options

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -2,7 +2,8 @@ MAN = time-sheet.3
 PDF = time-sheet.pdf
 HTML = time-sheet.html
 
-COMMONOPTIONS = --self-contained --number-sections --normalize --smart --toc
+INPUT_FORMAT = -f markdown+smart
+COMMONOPTIONS = --self-contained --number-sections --toc
 
 TEX_META = -V date='\today' --highlight-style=monochrome
 HTML_META = -c manual.css
@@ -18,11 +19,11 @@ pdf: $(PDF)
 html: $(HTML)
 
 time-sheet.3: time-sheet.mdwn
-	pandoc -t man $(COMMONOPTIONS) $(MAIN_MAN_META) -o $@ time-sheet.mdwn
+	pandoc -t man $(INPUT_FORMAT) $(COMMONOPTIONS) $(MAIN_MAN_META) -o $@ time-sheet.mdwn
 time-sheet.pdf: time-sheet.mdwn
-	pandoc --template template.latex $(COMMONOPTIONS) $(TEX_META) $(MAIN_TEX_META) -o $@ time-sheet.mdwn
+	pandoc --template template.latex $(INPUT_FORMAT) $(COMMONOPTIONS) $(TEX_META) $(MAIN_TEX_META) -o $@ time-sheet.mdwn
 time-sheet.html: time-sheet.mdwn
-	pandoc -t html5 $(HTML_META) $(COMMONOPTIONS) $(MAIN_HTML_META) -o $@ time-sheet.mdwn
+	pandoc -t html5 $(INPUT_FORMAT) $(HTML_META) $(COMMONOPTIONS) $(MAIN_HTML_META) -o $@ time-sheet.mdwn
 
 clean:
 	rm -f $(HTML) $(PDF) $(MAN) *~


### PR DESCRIPTION
--normalize has been removed.  Normalization is now automatic.
--smart/-S has been removed.  Use +smart or -smart extension instead.